### PR TITLE
Fix typo in path to include usr/sbin/* files of s6

### DIFF
--- a/s6/debian/s6.install
+++ b/s6/debian/s6.install
@@ -1,3 +1,3 @@
 usr/bin/*
-usr/bin/*
+usr/sbin/*
 usr/lib/*.so.* usr/lib/*/*.so.*


### PR DESCRIPTION
s6-setuidgid and s6-applyuidgid was missing in the package
